### PR TITLE
Add ability to clear hash

### DIFF
--- a/uci/cmd.go
+++ b/uci/cmd.go
@@ -129,7 +129,6 @@ var (
 //	 "setoption name Nullmove value true\n"
 //	"setoption name Selectivity value 3\n"
 //	 "setoption name Style value Risky\n"
-//	 "setoption name Clear Hash\n"
 //	 "setoption name NalimovPath value c:\chess\tb\4;c:\chess\tb\5\n"
 type CmdSetOption struct {
 	Name  string
@@ -142,6 +141,21 @@ func (cmd CmdSetOption) String() string {
 
 // ProcessResponse implements the Cmd interface
 func (cmd CmdSetOption) ProcessResponse(e *Engine) error {
+	return nil
+}
+
+// CmdClearHash corresponds to the "setoption name clear hash" command:
+//
+//	"setoption name Clear Hash\n"
+type CmdSetOptionClearHash struct {
+}
+
+func (cmd CmdSetOptionClearHash) String() string {
+	return fmt.Sprintf("setoption name clear hash")
+}
+
+// ProcessResponse implements the Cmd interface
+func (cmd CmdSetOptionClearHash) ProcessResponse(e *Engine) error {
 	return nil
 }
 


### PR DESCRIPTION
When the move the player plays is not in the top X moves list, PGN-Spy has to issue a new search command to discover what the evaluation of a given move actually is. When doing so, it will [clear the hash](https://github.com/MGleason1/PGN-Spy/blob/54aa66e4824b354da2471b5c503d0b17de881273/uci-analyser/analyse.cpp#L521) and we need to do the same. 

The current `CmdSetOption` will produce a UCI command of `setoption name clear value hash` when the command needs to be `   `setoption name clear hash` as per [this line](https://github.com/MGleason1/PGN-Spy/blob/master/uci-analyser/engine.cpp#L41C1-L41C38).

This PR adds a new command for clearing the hash.