### PR TITLE
feat: Adding a PGN-Spy mode

### DIFF
--- a/uci/engine.go
+++ b/uci/engine.go
@@ -172,6 +172,16 @@ func (e *Engine) processCommand(cmd Cmd) error {
 	return nil
 }
 
+func (e *Engine) stop() error {
+	if e.debug {
+		e.logger.Println("stop")
+	}
+	if _, err := fmt.Fprintln(e.in, "stop"); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (e *Engine) readLine(scanner *bufio.Scanner) string {
 	s := scanner.Text()
 	if e.debug {


### PR DESCRIPTION
This copies the way that PGN-Spy controls stockfish for its analysis. Long term this should go in the analysis-worker IMO, but I don't have time to do it that way right now.

What do we think?